### PR TITLE
Fix for Real Time Endpoint deploy

### DIFF
--- a/environment/train-conda.yml
+++ b/environment/train-conda.yml
@@ -1,16 +1,17 @@
 channels:
-  - defaults
-  - anaconda
   - conda-forge
 dependencies:
-  - python=3.7.5
-  - pip
+  - python=3.8
+  - numpy=1.21.2
+  - pip=21.2.4
+  - scikit-learn=0.24.2
+  - scipy=1.7.1
+  - pandas>=1.1,<1.2
+  - matplotlib=3.5.3
+  - joblib=1.4.2
   - pip:
-      - azureml-mlflow==1.38.0
-      - azure-ai-ml==1.0.0
-      - pyarrow==10.0.0
+      - inference-schema[numpy-support]==1.3.0
+      - xlrd==2.0.1
+      - azureml-mlflow==1.51.0
       - ruamel.yaml==0.17.21
-      - scikit-learn==0.24.1
-      - pandas==1.2.1
-      - joblib==1.0.0
-      - matplotlib==3.3.3
+      - pyarrow==10.0.0


### PR DESCRIPTION
The real time endpoint deploy is failing because of an incompatibility in the library of the current conda env.

This PR provide a new version of the train-conda.yml that fix the issue